### PR TITLE
fix(logging): python-json-logger is listed as an optional dependency, but without it installed there are errors #3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pythonik-ext"
-version = "2025.4.1-beta"
+version = "2025.4.2-beta"
 description = "Extensions and enhancements for the pythonik client library"
 readme = "README.md"
 authors = [{ name = "Brian Summa", email = "brian.f.summa@chesa.com" }]

--- a/src/pythonikext/__version__.py
+++ b/src/pythonikext/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "2025.4.1-beta"
+__version__ = "2025.4.2-beta"

--- a/src/pythonikext/_logging.py
+++ b/src/pythonikext/_logging.py
@@ -11,21 +11,20 @@ from typing import Any, Dict, Optional, Union
 
 # Handle both old and new pythonjsonlogger import locations
 JSON_LOGGING_AVAILABLE = False
+JsonFormatter = None
 try:
     # Try new import location first
     from pythonjsonlogger.json import JsonFormatter
-
     JSON_LOGGING_AVAILABLE = True
 except ImportError:
     try:
         # Fall back to old import location
         from pythonjsonlogger.jsonlogger import JsonFormatter
-
         JSON_LOGGING_AVAILABLE = True
     except ImportError:
         # Package not available
-        JsonFormatter = None
         JSON_LOGGING_AVAILABLE = False
+        JsonFormatter = None
 
 # Constants
 VALID_LOG_FORMATS = ["text", "json"]
@@ -37,43 +36,45 @@ try:
 except ImportError:
     VERSION = "unknown"
 
+# Only define PythonikJsonFormatter if JsonFormatter is available
+if JSON_LOGGING_AVAILABLE:
 
-class PythonikJsonFormatter(JsonFormatter):
-    """Custom JSON formatter with additional fields."""
+    class PythonikJsonFormatter(JsonFormatter):
+        """Custom JSON formatter with additional fields."""
 
-    def __init__(
-        self,
-        app_name: str = "pythonik-ext",
-        extra_fields: Optional[Dict[str, Any]] = None
-    ):
-        """
-        Initialize the JSON formatter.
+        def __init__(
+            self,
+            app_name: str = "pythonik-ext",
+            extra_fields: Optional[Dict[str, Any]] = None
+        ):
+            """
+            Initialize the JSON formatter.
 
-        Args:
-            app_name: Name of the application
-            extra_fields: Additional fields to include in every log entry
-        """
-        super().__init__()
-        self.app_name = app_name
-        self.extra_fields = extra_fields or {}
+            Args:
+                app_name: Name of the application
+                extra_fields: Additional fields to include in every log entry
+            """
+            super().__init__()
+            self.app_name = app_name
+            self.extra_fields = extra_fields or {}
 
-    def add_fields(
-        self, log_record: Dict[str, Any], record: logging.LogRecord,
-        message_dict: Dict[str, Any]
-    ) -> None:
-        """Add custom fields to the log record."""
-        super().add_fields(log_record, record, message_dict)
+        def add_fields(
+            self, log_record: Dict[str, Any], record: logging.LogRecord,
+            message_dict: Dict[str, Any]
+        ) -> None:
+            """Add custom fields to the log record."""
+            super().add_fields(log_record, record, message_dict)
 
-        # Add standard fields
-        log_record.update({
-            "@timestamp": datetime.now(timezone.utc).isoformat(),
-            "app": self.app_name,
-            "version": VERSION,
-            "logger": record.name,
-        })
+            # Add standard fields
+            log_record.update({
+                "@timestamp": datetime.now(timezone.utc).isoformat(),
+                "app": self.app_name,
+                "version": VERSION,
+                "logger": record.name,
+            })
 
-        # Add any extra fields
-        log_record.update(self.extra_fields)
+            # Add any extra fields
+            log_record.update(self.extra_fields)
 
 
 class LogConfig:


### PR DESCRIPTION
1. Moved the `JsonFormatter = None` declaration before the import attempts to ensure it's always defined.
2. Wrapped the `PythonikJsonFormatter` class definition inside a conditional check:

```python
if JSON_LOGGING_AVAILABLE:
  class PythonikJsonFormatter(JsonFormatter):
      # Class implementation...
```

This way, the class is only defined when `JsonFormatter` is available, avoiding the `TypeError` when `python-json-logger` isn't installed.

The rest of the code already has appropriate checks to verify JSON logging is available before trying to use `PythonikJsonFormatter`, so those parts didn't need changes.

This solution maintains all the functionality of the original code while handling the optional dependency correctly. When `python-json-logger` is not installed, the module will load successfully, and if JSON logging is requested, it will raise a clear ImportError with instructions on how to install the package.

Version: 2025.4.2